### PR TITLE
GitHub Pages for Documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: GitHub Pages
+on:
+  push:
+    branches:
+      - pages # For testing
+      - master
+
+jobs:
+  gh-pages:
+    name: deploy docs
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        python-version: [3.7]
+        os: [ubuntu-latest]
+      fail-fast: False
+    steps:
+      - uses: actions/checkout@v1
+      - name: Initialize submodules
+        run:
+          git submodule update --init --recursive
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -W ignore -m pip install --upgrade pip
+          python -W ignore -m pip install -r requirements.txt
+          python -W ignore -m pip install -r requirements-dev.txt
+          python -W ignore -m pip install -r docs/requirements-docs.txt
+      - name: Deploy to GitHub Pages
+        run: |
+          docs/deploy-gh-pages.sh
+        env:
+          GH_NAME: ${{ secrets.GH_NAME }}
+          GH_EMAIL: ${{ secrets.GH_EMAIL }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        shell: bash

--- a/README.rst
+++ b/README.rst
@@ -5,3 +5,5 @@ A Telegram bot designed to help the members of the »Akademische Bläservereinig
 You can find it at `@AkaNamenBot`_.
 
 .. _`@AkaNamenBot`: http://t.me/AkaNamenBot
+
+The docs are gonna be set up using github pages

--- a/README.rst
+++ b/README.rst
@@ -6,4 +6,4 @@ You can find it at `@AkaNamenBot`_.
 
 .. _`@AkaNamenBot`: http://t.me/AkaNamenBot
 
-The docs are gonna be set up using github pages
+The docs are gonna be set up using GitHub Pages

--- a/docs/deploy-gh-pages.sh
+++ b/docs/deploy-gh-pages.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Fail out on an error
+set -e
+
+# CD into docs, make them. If you're not using Sphinx, you'll probably
+# have a different build script.
+make -C docs/ clean html
+
+# Move the docs to the top-level directory, stash for checkout
+mv docs/build/html/ .
+
+# The html/ directory will stay there when we stash
+git stash --include-untracked
+
+# Checkout our gh-pages branch, remove everything but .git
+git checkout gh-pages
+git pull origin gh-pages
+
+# Make sure to set the credentials! You'll need these environment vars
+# set in the "Environment Variables" section in Circle CI
+git config --global user.email "$GH_EMAIL" > /dev/null 2>&1
+git config --global user.name "$GH_NAME" > /dev/null 2>&1
+
+# Remove all files that are not in the .git dir
+git rm -rf .
+git clean -fxd
+
+# We need this empty file for git not to try to build a jekyll project.
+# If your project *is* Jekyll, then this doesn't apply to you...
+touch .nojekyll
+git stash apply
+mv html/* .
+rm -r html/
+
+# Add everything, get ready for commit. 
+git add --all
+git commit -m "Publishing Updated Documentation"
+
+# We have to re-add the origin with the GH_TOKEN credentials. You
+# will need this SSH key in your environment variables.
+# Make sure you change the <project>.git pattern at the end!
+git remote rm origin
+git remote add origin https://"$GH_NAME":"$GH_TOKEN"@github.com/"$GH_NAME"/AkaNamen-Bot.git
+
+# NOW we should be able to push it
+git push origin gh-pages


### PR DESCRIPTION
Sets up GitHub Pages for hosting documentation
Docs are build on push to master and pushed to the `gh-pages` branch automatically.