### PR TITLE
Manually add missing + in phone numbers

### DIFF
--- a/bot/editing.py
+++ b/bot/editing.py
@@ -536,6 +536,8 @@ def phone_number(update: Update, context: CallbackContext) -> str:
 
     if update.message:
         number = update.message.contact.phone_number
+        if number.startswith('49'):
+            number = f'+{number}'
         member.phone_number = number
         orchestra.update_member(member)
 


### PR DESCRIPTION
The number is passed by Telegram, so I can't really check, if it supposed to be there. For now, just add +, if the number starts with `49`. Should suffice for the most cases.

Closes #16 