### PR TITLE
Fix photo questions and add admin stuff

### DIFF
--- a/bot/admin.py
+++ b/bot/admin.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""This module contains functions for the admin."""
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from bot import ORCHESTRA_KEY
+from components import Orchestra
+
+
+def rebuild_orchestra(update: Update, context: CallbackContext) -> None:
+    """
+    Builds a new orchestra by registering all members from the one in ``context.bot_data`` to a
+    new instance of :class:`components.Orchestra`. Puts the new orchestra in ``bot_data``.
+    Useful, if there have been changes to the attribute manager setup.
+
+    Args:
+        update: The update.
+        context: The context as provided by the :class:`telegram.ext.Dispatcher`.
+    """
+    members = context.bot_data[ORCHESTRA_KEY].members.values()
+    orchestra = Orchestra()
+
+    for m in members:
+        orchestra.register_member(m)
+
+    context.bot_data[ORCHESTRA_KEY] = orchestra
+    update.message.reply_text('Orchester neu besetzt.')

--- a/bot/game.py
+++ b/bot/game.py
@@ -147,7 +147,7 @@ class QuestionHandler(Handler):
             True: If the update is to be handled
             False: Otherwise.
         """
-        if Filters.command(update):
+        if update.effective_message and Filters.command(update):
             return False
         user_id = update.effective_user.id
         with self._questioners_lock:

--- a/bot/setup.py
+++ b/bot/setup.py
@@ -20,6 +20,7 @@ import bot.inline as inline
 import bot.highscore as highscore
 import bot.error as error
 import bot.game as game
+import bot.admin
 
 from components import Orchestra
 
@@ -112,6 +113,10 @@ def register_dispatcher(dispatcher: Dispatcher, admin: Union[int, str]) -> None:
 
     # Set commands
     dispatcher.bot.set_my_commands(BOT_COMMANDS)
+
+    # Admin stuff
+    dispatcher.add_handler(
+        CommandHandler('rebuild', bot.admin.rebuild_orchestra, filters=Filters.user(int(admin))))
 
     # Schedule job deleting users who blocked the bot
     schedule_daily_job(dispatcher)

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -10,7 +10,8 @@ from .instruments import (Instrument, WoodwindInstrument, BrassInstrument, HighB
                           BaritoneSaxophone, Euphonium, Baritone, BaritoneHorn, Trombone, Tuba,
                           Trumpet, Flugelhorn, Horn, Drums, Guitar, BassGuitar, Conductor)
 from .gender import Gender
-from .attributemanager import AttributeManager, NameManager, ChangingAttributeManager
+from .attributemanager import (AttributeManager, NameManager, PhotoManager,
+                               ChangingAttributeManager)
 from .score import Score
 from .userscore import UserScore
 from .member import Member
@@ -54,6 +55,7 @@ __all__ = [
     'Orchestra',
     'AttributeManager',
     'NameManager',
+    'PhotoManager',
     'ChangingAttributeManager',
     # Game related
     'UserScore',

--- a/components/orchestra.py
+++ b/components/orchestra.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from threading import Lock
 
 from components import Member, PicklableBase, Score, AttributeManager, ChangingAttributeManager, \
-    NameManager
+    NameManager, PhotoManager
 
 from typing import Dict, List, Optional, Tuple, Any, Set, Iterable
 
@@ -56,9 +56,8 @@ class Orchestra(PicklableBase):
                     'nickname', list(self.ATTRIBUTE_MANAGERS.difference(['nickname',
                                                                          'full_name']))),
             'photo_file_id':
-                AttributeManager('photo_file_id',
-                                 list(self.ATTRIBUTE_MANAGERS.difference(['photo_file_id'])),
-                                 gendered_questions=True),
+                PhotoManager('photo_file_id',
+                             list(self.ATTRIBUTE_MANAGERS.difference(['photo_file_id']))),
         }
 
     def __getitem__(self, item: str) -> Any:

--- a/docs/source/bot.admin.rst
+++ b/docs/source/bot.admin.rst
@@ -1,0 +1,6 @@
+bot.admin Module
+================
+
+.. automodule:: bot.admin
+    :members:
+    :show-inheritance:

--- a/docs/source/bot.rst
+++ b/docs/source/bot.rst
@@ -3,6 +3,7 @@ Frontend: Bot package
 
 .. toctree::
 
+    bot.admin
     bot.ban
     bot.cancel_membership
     bot.check_user_status

--- a/tests/test_attributemanager.py
+++ b/tests/test_attributemanager.py
@@ -4,7 +4,7 @@ import datetime as dtm
 import pytest
 
 from components import Member, AttributeManager, NameManager, Gender, Tuba, Trombone, \
-    Trumpet, Drums, Bassoon, Clarinet, Horn, Flute, ChangingAttributeManager
+    Trumpet, Drums, Bassoon, Clarinet, Horn, Flute, ChangingAttributeManager, PhotoManager
 
 
 @pytest.fixture(scope='function')
@@ -730,6 +730,47 @@ class TestNameManager:
         assert member in bm.available_members
         assert attr == '100'
         assert correct == am.get_members_attribute(member)
+
+
+class TestPhotoAttributeManager:
+    description = 'photo_file_id'
+
+    @pytest.mark.parametrize('gender,other_gender', [(Gender.MALE, Gender.FEMALE),
+                                                     (Gender.FEMALE, Gender.MALE)])
+    def test_distinct_values_for_member(self, member, gender, other_gender):
+        am = PhotoManager(self.description, [])
+        bm = AttributeManager('last_name', [], gendered_questions=True)
+
+        for i in range(10):
+            am.register_member(Member(i, last_name='a', photo_file_id='b', gender=gender))
+
+        for g in [None, gender, other_gender]:
+            assert am.distinct_values_for_member(
+                bm, Member(100, last_name='a', photo_file_id='b', gender=g)) == set()
+            assert am.distinct_values_for_member(
+                bm, Member(100, last_name='c', photo_file_id='b', gender=g)) == set()
+
+        for i in range(5):
+            am.register_member(Member(i + 10, last_name=str(i), photo_file_id='b', gender=gender))
+
+        for g in [None, gender, other_gender]:
+            assert am.distinct_values_for_member(
+                bm, Member(100, last_name='a', photo_file_id='b', gender=g)) == set()
+            assert am.distinct_values_for_member(
+                bm, Member(100, last_name='c', photo_file_id='b', gender=g)) == set()
+
+        for i in range(5):
+            am.register_member(Member(i + 20, last_name='a', photo_file_id=str(i), gender=gender))
+
+        assert am.distinct_values_for_member(
+            bm, Member(100, last_name='a', photo_file_id='b', gender=gender)) == set()
+        assert am.distinct_values_for_member(
+            bm, Member(100, last_name='c', photo_file_id='b',
+                       gender=gender)) == {'0', '1', '2', '3', '4'}
+        assert am.distinct_values_for_member(
+            bm, Member(100, last_name='a', photo_file_id='b', gender=other_gender)) == set()
+        assert am.distinct_values_for_member(
+            bm, Member(100, last_name='c', photo_file_id='b', gender=other_gender)) == set()
 
 
 class TestChangingAttributeManager:

--- a/tests/test_orchestra.py
+++ b/tests/test_orchestra.py
@@ -280,9 +280,6 @@ class TestOrchestra:
         orchestra.register_member(Member(6, first_name='Brad', photo_file_id=str(uuid4())))
         orchestra.register_member(Member(7, first_name='Marc', photo_file_id=str(uuid4())))
         orchestra.register_member(Member(8, first_name='Joe', photo_file_id=str(uuid4())))
-        assert orchestra.questionable() == [('first_name', 'photo_file_id'),
-                                            ('full_name', 'photo_file_id')]
-        assert orchestra.questionable(multiple_choice=False) == [('first_name', 'photo_file_id'),
-                                                                 ('full_name', 'photo_file_id'),
-                                                                 ('photo_file_id', 'first_name'),
+        assert orchestra.questionable() == []
+        assert orchestra.questionable(multiple_choice=False) == [('photo_file_id', 'first_name'),
                                                                  ('photo_file_id', 'full_name')]


### PR DESCRIPTION
closes #58 

* Adds `PhotoManager` to make photos generable questions
* adds `/rebuild` command for admin to allow rebuilding the orchestra, when the attribute manager setup has changed